### PR TITLE
Fix bad call to `reset`

### DIFF
--- a/lib/replicate/active_record.rb
+++ b/lib/replicate/active_record.rb
@@ -161,7 +161,10 @@ module Replicate
           if reflection.macro == :has_and_belongs_to_many
             dump_has_and_belongs_to_many_replicant(dumper, reflection)
           end
-          __send__(reflection.name).reset # clear to allow GC
+          object = __send__(reflection.name) # clear to allow GC
+          if object.respond_to?(:reset)
+            object.reset
+          end
         else
           warn "error: #{self.class}##{association} is invalid"
         end


### PR DESCRIPTION
I'm not sure why this method is being invoked where it is, but at present replicate fails when trying to invoke `reset` on an instance of `Mls` when replicating properties. I have verified that checking to ensure the object responds to `reset` prior to invoking it allows replicate to work.