### PR TITLE
replace File.exists? with File.exist?

### DIFF
--- a/examples/ar-3.x/config/boot.rb
+++ b/examples/ar-3.x/config/boot.rb
@@ -3,4 +3,4 @@ require 'rubygems'
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])

--- a/lib/replicate/dumper.rb
+++ b/lib/replicate/dumper.rb
@@ -131,10 +131,10 @@ module Replicate
     protected
     def find_file(path)
       path = "#{path}.rb" unless path =~ /\.rb$/
-      return path if File.exists? path
+      return path if File.exist? path
       $LOAD_PATH.each do |prefix|
         full_path = File.expand_path(path, prefix)
-        return full_path if File.exists? full_path
+        return full_path if File.exist? full_path
       end
       false
     end


### PR DESCRIPTION
Issue: https://github.com/estately/estately/issues/24716

The `exists?` function was deprecated in Ruby 3.2. Here I replace `File.exists?` with `File.exist?`